### PR TITLE
add typename before dependent type name

### DIFF
--- a/include/tl/generator.hpp
+++ b/include/tl/generator.hpp
@@ -73,9 +73,9 @@ namespace tl {
          using handle_type = std::coroutine_handle<promise_type>;
 
       public:
-         using value_type = promise_type::value_type;
-         using reference_type = promise_type::reference_type;
-         using pointer_type = promise_type::pointer_type;
+         using value_type = typename promise_type::value_type;
+         using reference_type = typename promise_type::reference_type;
+         using pointer_type = typename promise_type::pointer_type;
          using difference_type = std::ptrdiff_t;
 
          iterator() = default;


### PR DESCRIPTION
to address the compiling failures from Clang-14, like:

./generator.hpp:76:29: error: missing 'typename' prior to dependent type
name 'promise_type::value_type'
         using value_type = promise_type::value_type;
                            ^~~~~~~~~~~~~~~~~~~~~~~~
                            typename
./generator.hpp:77:33: error: missing 'typename' prior to dependent type
name 'promise_type::reference_type'
         using reference_type = promise_type::reference_type;
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                typename
./generator.hpp:78:31: error: missing 'typename' prior to dependent type
name 'promise_type::pointer_type'
         using pointer_type = promise_type::pointer_type;
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~
                              typename

Signed-off-by: Kefu Chai <tchaikov@gmail.com>