### PR TITLE
Allow direct co_yield of a pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+build/

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -88,3 +88,20 @@ seven eight nine)";
       REQUIRE(val == result[i]);
    }
 }
+
+tl::generator<const char*> generate() {
+   co_yield "one";
+   co_yield "two";
+   co_yield "three";
+}
+
+TEST_CASE("pointers") {
+   std::vector<std::string> result = {
+      "one", "two", "three"
+   };
+   std::size_t i = 0;
+   for (auto&& val : generate()) {
+      REQUIRE(val == result[i]);
+      ++i;
+   }
+}


### PR DESCRIPTION
This PR allows `co_yield`ing a pointer.
Now this does not work:
```
tl::generator<int*> gen() {
  int i = ...;
  co_yield &i;
  //workaround:
  int* ret = &i;
  co_yield ret;
}
```